### PR TITLE
Add male-only tree view toggle and placeholders

### DIFF
--- a/client/src/components/CompactFamilyView.tsx
+++ b/client/src/components/CompactFamilyView.tsx
@@ -14,9 +14,10 @@ interface CompactFamilyViewProps {
   onAddMember: (relationship: string, relatedTo?: number) => void;
   centerPerson?: any;
   onCenterChange?: (person: any) => void;
+  showMalesOnly?: boolean;
 }
 
-export default function CompactFamilyView({ members, onDeleteMember, onAddMember, centerPerson: propCenterPerson, onCenterChange }: CompactFamilyViewProps) {
+export default function CompactFamilyView({ members, onDeleteMember, onAddMember, centerPerson: propCenterPerson, onCenterChange, showMalesOnly = false }: CompactFamilyViewProps) {
   const { user } = useAuth();
   const [localCenterPerson, setLocalCenterPerson] = useState<any>(null);
   const [showAllChildren, setShowAllChildren] = useState(false);
@@ -114,10 +115,32 @@ export default function CompactFamilyView({ members, onDeleteMember, onAddMember
 
   const family = getImmediateFamily(currentCenter);
 
-  const renderPersonCard = (person: any, relationship: string, size: 'sm' | 'md' | 'lg' = 'md', onClickAdd?: () => void) => {
+  const renderPersonCard = (
+    person: any,
+    relationship: string,
+    size: 'sm' | 'md' | 'lg' = 'md',
+    onClickAdd?: () => void,
+    filteredOut: boolean = false
+  ) => {
     if (!person) {
+      if (filteredOut) {
+        return (
+          <div className="flex flex-col items-center p-2">
+            <div
+              className={`
+                ${size === 'lg' ? 'w-16 h-16' : size === 'md' ? 'w-12 h-12' : 'w-10 h-10'}
+                border-2 border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-100
+              `}
+            >
+              <i className="fas fa-user-slash text-gray-400 text-sm"></i>
+            </div>
+            <div className="text-xs text-gray-400 mt-1 text-center">مخفي</div>
+          </div>
+        );
+      }
+
       return (
-        <div 
+        <div
           onClick={onClickAdd}
           className="flex flex-col items-center cursor-pointer group p-2"
         >
@@ -319,7 +342,8 @@ export default function CompactFamilyView({ members, onDeleteMember, onAddMember
                 family.mother,
                 'إضافة الأم',
                 'md',
-                () => onAddMember('mother', currentCenter.id)
+                showMalesOnly ? undefined : () => onAddMember('mother', currentCenter.id),
+                showMalesOnly && !family.mother
               )}
             </div>
           </div>
@@ -332,7 +356,8 @@ export default function CompactFamilyView({ members, onDeleteMember, onAddMember
                 family.spouse,
                 'إضافة زوج/زوجة',
                 'md',
-                () => onAddMember('spouse', currentCenter.id)
+                showMalesOnly ? undefined : () => onAddMember('spouse', currentCenter.id),
+                showMalesOnly && !family.spouse
               )}
             </div>
             <div className="text-center">

--- a/client/src/components/FamilyView.tsx
+++ b/client/src/components/FamilyView.tsx
@@ -130,10 +130,32 @@ export default function FamilyView({ members, onDeleteMember, onAddMember, cente
 
 
 
-  const renderPersonCard = (person: any, relationship: string, size: 'sm' | 'md' | 'lg' = 'md', onClickAdd?: () => void) => {
+  const renderPersonCard = (
+    person: any,
+    relationship: string,
+    size: 'sm' | 'md' | 'lg' = 'md',
+    onClickAdd?: () => void,
+    filteredOut: boolean = false
+  ) => {
     if (!person) {
+      if (filteredOut) {
+        return (
+          <div className="flex flex-col items-center">
+            <div
+              className={`
+                ${size === 'lg' ? 'w-24 h-24' : size === 'md' ? 'w-20 h-20' : 'w-16 h-16'}
+                border-2 border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-100
+              `}
+            >
+              <i className="fas fa-user-slash text-gray-400"></i>
+            </div>
+            <div className="text-xs text-gray-400 mt-2 text-center">مخفي</div>
+          </div>
+        );
+      }
+
       return (
-        <div 
+        <div
           onClick={onClickAdd}
           className="flex flex-col items-center cursor-pointer group"
         >
@@ -289,27 +311,30 @@ export default function FamilyView({ members, onDeleteMember, onAddMember, cente
               )}
             </div>
             <div className="text-center">
-              {renderPersonCard(
+            {renderPersonCard(
                 relatives.paternalGrandmother,
                 'جدة الأب',
                 'sm',
-                () => onAddMember('paternalGrandmother', currentCenter.id)
+                showMalesOnly ? undefined : () => onAddMember('paternalGrandmother', currentCenter.id),
+                showMalesOnly && !relatives.paternalGrandmother
               )}
             </div>
             <div className="text-center">
-              {renderPersonCard(
+            {renderPersonCard(
                 relatives.maternalGrandfather,
                 'جد الأم',
                 'sm',
-                () => onAddMember('maternalGrandfather', currentCenter.id)
+                showMalesOnly ? undefined : () => onAddMember('maternalGrandfather', currentCenter.id),
+                showMalesOnly && !relatives.maternalGrandfather
               )}
             </div>
             <div className="text-center">
-              {renderPersonCard(
+            {renderPersonCard(
                 relatives.maternalGrandmother,
                 'جدة الأم',
                 'sm',
-                () => onAddMember('maternalGrandmother', currentCenter.id)
+                showMalesOnly ? undefined : () => onAddMember('maternalGrandmother', currentCenter.id),
+                showMalesOnly && !relatives.maternalGrandmother
               )}
             </div>
           </div>
@@ -333,7 +358,7 @@ export default function FamilyView({ members, onDeleteMember, onAddMember, cente
           <div className="grid grid-cols-4 gap-8 mb-8 relative" style={{ zIndex: 2 }}>
             <div></div>
             <div className="text-center">
-              {renderPersonCard(
+            {renderPersonCard(
                 relatives.father,
                 'الأب',
                 'md',
@@ -341,11 +366,12 @@ export default function FamilyView({ members, onDeleteMember, onAddMember, cente
               )}
             </div>
             <div className="text-center">
-              {renderPersonCard(
+            {renderPersonCard(
                 relatives.mother,
                 'الأم',
                 'md',
-                () => onAddMember('mother', currentCenter.id)
+                showMalesOnly ? undefined : () => onAddMember('mother', currentCenter.id),
+                showMalesOnly && !relatives.mother
               )}
             </div>
             <div></div>
@@ -362,11 +388,12 @@ export default function FamilyView({ members, onDeleteMember, onAddMember, cente
           {/* Center Person Row */}
           <div className="grid grid-cols-3 gap-8 mb-8 items-center relative" style={{ zIndex: 2 }}>
             <div className="text-center">
-              {renderPersonCard(
+            {renderPersonCard(
                 relatives.spouse,
                 'الزوج/الزوجة',
                 'md',
-                () => onAddMember('spouse', currentCenter.id)
+                showMalesOnly ? undefined : () => onAddMember('spouse', currentCenter.id),
+                showMalesOnly && !relatives.spouse
               )}
             </div>
             <div className="text-center">

--- a/client/src/pages/FamilyTree.tsx
+++ b/client/src/pages/FamilyTree.tsx
@@ -5,6 +5,8 @@ import Footer from "@/components/Footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import AddMemberForm from "@/components/AddMemberForm";
@@ -134,12 +136,13 @@ export default function FamilyTree() {
     switch (currentView) {
       case 'compact':
         return (
-          <CompactFamilyView 
-            members={filteredMembers} 
+          <CompactFamilyView
+            members={filteredMembers}
             onDeleteMember={(id) => deleteMutation.mutate(id)}
             onAddMember={handleAddMember}
             centerPerson={centerPerson}
             onCenterChange={setCenterPerson}
+            showMalesOnly={showMalesOnly}
           />
         );
       case 'family':
@@ -235,20 +238,13 @@ export default function FamilyTree() {
           </Button>
           </div>
           
-          <div className="flex gap-2">
-            <Button
-              onClick={() => setShowMalesOnly(!showMalesOnly)}
-              variant={showMalesOnly ? 'default' : 'outline'}
-              className="gap-2"
-            >
-              <UserCheck className="h-4 w-4" />
-              {showMalesOnly ? 'إظهار الكل' : 'الرجال فقط'}
-            </Button>
-            {showMalesOnly && (
-              <Badge variant="secondary" className="self-center">
-                {filteredMembers.length} رجل
-              </Badge>
-            )}
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="male-only-switch"
+              checked={showMalesOnly}
+              onCheckedChange={setShowMalesOnly}
+            />
+            <Label htmlFor="male-only-switch">عرض الذكور فقط</Label>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- filter member list with a new male-only toggle on the family tree page
- show placeholder cards when relatives are filtered out in `FamilyView` and `CompactFamilyView`
- expose `showMalesOnly` prop to compact view

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686fc23e65a8832aae37a2cb0311276d