### PR TITLE
Add news interactions and header redesign

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,6 +1,22 @@
 import { useState } from "react";
 import { Link, useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  navigationMenuTriggerStyle,
+} from "@/components/ui/navigation-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
 
 export default function Header() {
@@ -30,50 +46,51 @@ export default function Header() {
           </div>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:block">
-            <div className="mr-10 flex items-baseline space-x-4 space-x-reverse">
-              {navigation.map((item) => (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                    location === item.href
-                      ? "text-heritage-brown border-b-2 border-heritage-brown"
-                      : "text-heritage-dark hover:text-heritage-brown"
-                  }`}
-                >
-                  {item.name}
-                </Link>
-              ))}
-            </div>
+          <div className="hidden md:block mr-10">
+            <NavigationMenu>
+              <NavigationMenuList>
+                {navigation.map((item) => (
+                  <NavigationMenuItem key={item.name}>
+                    <Link href={item.href}>
+                      <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                        {item.name}
+                      </NavigationMenuLink>
+                    </Link>
+                  </NavigationMenuItem>
+                ))}
+              </NavigationMenuList>
+            </NavigationMenu>
           </div>
 
           {/* User Menu */}
           <div className="flex items-center space-x-4 space-x-reverse">
-            <div className="flex items-center space-x-2 space-x-reverse">
-              {user?.profileImageUrl ? (
-                <img
-                  src={user.profileImageUrl}
-                  alt="صورة الملف الشخصي"
-                  className="w-8 h-8 rounded-full"
-                />
-              ) : (
-                <div className="w-8 h-8 rounded-full bg-heritage-brown text-white flex items-center justify-center">
-                  <i className="fas fa-user text-sm"></i>
-                </div>
-              )}
-              <span className="text-heritage-dark font-medium hidden sm:block">
-                {user?.firstName || user?.email || "المستخدم"}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => window.location.href = "/api/logout"}
-                className="text-heritage-dark hover:text-heritage-brown"
-              >
-                <i className="fas fa-sign-out-alt"></i>
-              </Button>
-            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="relative h-8 w-8 rounded-full">
+                  <Avatar className="h-8 w-8">
+                    <AvatarImage src={user?.profileImageUrl} alt={user?.firstName} />
+                    <AvatarFallback>{user?.firstName?.[0]}</AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56" align="end" forceMount>
+                <DropdownMenuLabel className="font-normal">
+                  <div className="flex flex-col space-y-1">
+                    <p className="text-sm font-medium leading-none">{user?.firstName} {user?.lastName}</p>
+                    <p className="text-xs leading-none text-muted-foreground">
+                      {user?.email}
+                    </p>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>Profile</DropdownMenuItem>
+                <DropdownMenuItem>Settings</DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => window.location.href = "/api/logout"}>
+                  Log out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             {/* Mobile menu button */}
             <div className="md:hidden">

--- a/client/src/components/NewsCard.tsx
+++ b/client/src/components/NewsCard.tsx
@@ -1,3 +1,7 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 interface NewsCardProps {
   news: any;
   compact?: boolean;
@@ -14,6 +18,45 @@ export default function NewsCard({ news, compact = false }: NewsCardProps) {
     if (diffDays < 7) return `منذ ${diffDays} أيام`;
     if (diffDays < 30) return `منذ ${Math.ceil(diffDays / 7)} أسابيع`;
     return date.toLocaleDateString('ar-SA');
+  };
+
+  const [likes, setLikes] = useState<number>(news.likesCount || 0);
+  const [comments, setComments] = useState<any[]>([]);
+  const [commentText, setCommentText] = useState("");
+  const [showComments, setShowComments] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/family-news/${news.id}/comments`, { credentials: "include" })
+      .then((res) => res.json())
+      .then(setComments)
+      .catch(() => {});
+  }, [news.id]);
+
+  const handleLike = async () => {
+    const res = await fetch(`/api/family-news/${news.id}/like`, {
+      method: "POST",
+      credentials: "include",
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setLikes(data.likes);
+    }
+  };
+
+  const handleAddComment = async () => {
+    if (!commentText.trim()) return;
+    const res = await fetch(`/api/family-news/${news.id}/comments`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: commentText }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setComments([data, ...comments]);
+      setCommentText("");
+      setShowComments(true);
+    }
   };
 
   if (compact) {
@@ -58,6 +101,40 @@ export default function NewsCard({ news, compact = false }: NewsCardProps) {
             <span>أضافه مدير العائلة</span>
           </div>
         </div>
+        <div className="flex items-center space-x-4 space-x-reverse mt-4">
+          <Button variant="ghost" size="sm" onClick={handleLike}>
+            <i className="fas fa-heart ml-2"></i>
+            {likes}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowComments(!showComments)}
+          >
+            <i className="fas fa-comment ml-2"></i>
+            {comments.length}
+          </Button>
+        </div>
+        {showComments && (
+          <div className="mt-4 space-y-2">
+            <div className="flex items-center space-x-2 space-x-reverse">
+              <Input
+                value={commentText}
+                onChange={(e) => setCommentText(e.target.value)}
+                placeholder="اكتب تعليقك"
+                className="flex-1"
+              />
+              <Button size="sm" onClick={handleAddComment}>
+                إرسال
+              </Button>
+            </div>
+            {comments.map((c) => (
+              <div key={c.id} className="border rounded p-2 text-sm">
+                {c.content}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -621,7 +621,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const userId = req.user.claims.sub;
       const news = await storage.getFamilyNews(userId);
-      res.json(news);
+      const newsWithCounts = await Promise.all(
+        news.map(async (n) => {
+          const likes = await storage.getFamilyNewsLikes(n.id);
+          const comments = await storage.getFamilyNewsComments(n.id);
+          return { ...n, likesCount: likes, commentsCount: comments.length };
+        })
+      );
+      res.json(newsWithCounts);
     } catch (error) {
       console.error("Error fetching family news:", error);
       res.status(500).json({ message: "Failed to fetch family news" });
@@ -648,6 +655,57 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error creating family news:", error);
       res.status(500).json({ message: "Failed to create family news" });
+    }
+  });
+
+  app.post("/api/family-news/:id/like", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user.claims.sub;
+      const newsId = parseInt(req.params.id);
+      await storage.likeFamilyNews(newsId, userId);
+      const count = await storage.getFamilyNewsLikes(newsId);
+      res.json({ likes: count });
+    } catch (error) {
+      console.error("Error liking news:", error);
+      res.status(500).json({ message: "Failed to like news" });
+    }
+  });
+
+  app.delete("/api/family-news/:id/like", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user.claims.sub;
+      const newsId = parseInt(req.params.id);
+      await storage.unlikeFamilyNews(newsId, userId);
+      const count = await storage.getFamilyNewsLikes(newsId);
+      res.json({ likes: count });
+    } catch (error) {
+      console.error("Error unliking news:", error);
+      res.status(500).json({ message: "Failed to unlike news" });
+    }
+  });
+
+  app.post("/api/family-news/:id/comments", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user.claims.sub;
+      const newsId = parseInt(req.params.id);
+      const { content } = req.body;
+      if (!content) return res.status(400).json({ message: "Content required" });
+      const comment = await storage.createFamilyNewsComment({ newsId, userId, content });
+      res.json(comment);
+    } catch (error) {
+      console.error("Error adding comment:", error);
+      res.status(500).json({ message: "Failed to add comment" });
+    }
+  });
+
+  app.get("/api/family-news/:id/comments", isAuthenticated, async (req: any, res) => {
+    try {
+      const newsId = parseInt(req.params.id);
+      const comments = await storage.getFamilyNewsComments(newsId);
+      res.json(comments);
+    } catch (error) {
+      console.error("Error fetching comments:", error);
+      res.status(500).json({ message: "Failed to fetch comments" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2,6 +2,8 @@ import {
   users,
   familyMembers,
   familyNews,
+  familyNewsLikes,
+  familyNewsComments,
   familyDocuments,
   familyPhotos,
   familyInvitations,
@@ -13,6 +15,10 @@ import {
   type InsertFamilyMember,
   type FamilyNews,
   type InsertFamilyNews,
+  type InsertFamilyNewsLike,
+  type FamilyNewsLike,
+  type InsertFamilyNewsComment,
+  type FamilyNewsComment,
   type FamilyDocument,
   type InsertFamilyDocument,
   type FamilyPhoto,
@@ -21,7 +27,7 @@ import {
   type InsertFamilyInvitation,
 } from "@shared/schema";
 import { db } from "./db";
-import { eq, desc, and } from "drizzle-orm";
+import { eq, desc, and, sql } from "drizzle-orm";
 
 export interface IStorage {
   // User operations (mandatory for Replit Auth)
@@ -42,6 +48,12 @@ export interface IStorage {
   createFamilyNews(news: InsertFamilyNews): Promise<FamilyNews>;
   updateFamilyNews(id: number, news: Partial<InsertFamilyNews>): Promise<FamilyNews>;
   deleteFamilyNews(id: number): Promise<void>;
+
+  likeFamilyNews(newsId: number, userId: string): Promise<void>;
+  unlikeFamilyNews(newsId: number, userId: string): Promise<void>;
+  getFamilyNewsLikes(newsId: number): Promise<number>;
+  createFamilyNewsComment(comment: InsertFamilyNewsComment): Promise<FamilyNewsComment>;
+  getFamilyNewsComments(newsId: number): Promise<FamilyNewsComment[]>;
 
   // Family document operations
   getFamilyDocuments(userId: string): Promise<FamilyDocument[]>;
@@ -173,6 +185,43 @@ export class DatabaseStorage implements IStorage {
 
   async deleteFamilyNews(id: number): Promise<void> {
     await db.delete(familyNews).where(eq(familyNews.id, id));
+  }
+
+  async likeFamilyNews(newsId: number, userId: string): Promise<void> {
+    await db
+      .insert(familyNewsLikes)
+      .values({ newsId, userId })
+      .onConflictDoNothing();
+  }
+
+  async unlikeFamilyNews(newsId: number, userId: string): Promise<void> {
+    await db
+      .delete(familyNewsLikes)
+      .where(and(eq(familyNewsLikes.newsId, newsId), eq(familyNewsLikes.userId, userId)));
+  }
+
+  async getFamilyNewsLikes(newsId: number): Promise<number> {
+    const [result] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(familyNewsLikes)
+      .where(eq(familyNewsLikes.newsId, newsId));
+    return Number(result?.count) || 0;
+  }
+
+  async createFamilyNewsComment(comment: InsertFamilyNewsComment): Promise<FamilyNewsComment> {
+    const [newComment] = await db
+      .insert(familyNewsComments)
+      .values(comment)
+      .returning();
+    return newComment;
+  }
+
+  async getFamilyNewsComments(newsId: number): Promise<FamilyNewsComment[]> {
+    return await db
+      .select()
+      .from(familyNewsComments)
+      .where(eq(familyNewsComments.newsId, newsId))
+      .orderBy(desc(familyNewsComments.createdAt));
   }
 
   // Family document operations

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -94,6 +94,23 @@ export const familyNews = pgTable("family_news", {
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
+// Likes on family news articles
+export const familyNewsLikes = pgTable("family_news_likes", {
+  id: serial("id").primaryKey(),
+  newsId: integer("news_id").references(() => familyNews.id),
+  userId: varchar("user_id").references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+// Comments on family news articles
+export const familyNewsComments = pgTable("family_news_comments", {
+  id: serial("id").primaryKey(),
+  newsId: integer("news_id").references(() => familyNews.id),
+  userId: varchar("user_id").references(() => users.id),
+  content: text("content").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Family documents table
 export const familyDocuments = pgTable("family_documents", {
   id: serial("id").primaryKey(),
@@ -163,6 +180,12 @@ export type FamilyMember = typeof familyMembers.$inferSelect;
 export type InsertFamilyNews = typeof familyNews.$inferInsert;
 export type FamilyNews = typeof familyNews.$inferSelect;
 
+export type InsertFamilyNewsLike = typeof familyNewsLikes.$inferInsert;
+export type FamilyNewsLike = typeof familyNewsLikes.$inferSelect;
+
+export type InsertFamilyNewsComment = typeof familyNewsComments.$inferInsert;
+export type FamilyNewsComment = typeof familyNewsComments.$inferSelect;
+
 export type InsertFamilyDocument = typeof familyDocuments.$inferInsert;
 export type FamilyDocument = typeof familyDocuments.$inferSelect;
 
@@ -183,6 +206,16 @@ export const insertFamilyNewsSchema = createInsertSchema(familyNews).omit({
   id: true,
   createdAt: true,
   updatedAt: true,
+});
+
+export const insertFamilyNewsLikeSchema = createInsertSchema(familyNewsLikes).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertFamilyNewsCommentSchema = createInsertSchema(familyNewsComments).omit({
+  id: true,
+  createdAt: true,
 });
 
 export const insertFamilyDocumentSchema = createInsertSchema(familyDocuments).omit({


### PR DESCRIPTION
## Summary
- support likes and comments in the database
- expose APIs for liking/unliking and commenting on news
- handle new operations in storage layer
- show likes and comments in `NewsCard`
- modernize `Header` with shadcn components

## Testing
- `npm run check` *(fails: cannot compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_686fc2a07568832aa246dc2f5d826002